### PR TITLE
PY3K: `sievelib` expects `username` & `password` to be `str` not `bytes`

### DIFF
--- a/modoboa_sievefilters/lib.py
+++ b/modoboa_sievefilters/lib.py
@@ -43,8 +43,7 @@ class SieveClient(object):
         if authmech == "AUTO":
             authmech = None
         try:
-            ret = self.msc.connect(
-                smart_bytes(user), smart_bytes(password),
+            ret = self.msc.connect(user, password,
                 starttls=conf["starttls"], authmech=authmech)
         except managesieve.Error:
             ret = False

--- a/modoboa_sievefilters/mocks.py
+++ b/modoboa_sievefilters/mocks.py
@@ -36,8 +36,8 @@ class ManagesieveClientMock(object):
             "third_script": SAMPLE_SIEVE_SCRIPT2,
         }
 
-    def connect(self, *args, **kwargs):
-        return True
+    def connect(self, username, password, **kwargs):
+        return (username == "user@test.com" and password == "toto")
 
     def logout(self):
         return True


### PR DESCRIPTION
Bug introduced during refactoring, unit test updated to check for this.