### PR TITLE
Fix installation with pip >= 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ from __future__ import unicode_literals
 
 import io
 from os import path
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
pip.req was moved to the internal namespace.
Installing with newer pip version fails with:

  ModuleNotFoundError: No module named 'pip.req